### PR TITLE
feat: add support for desktop user-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ const { useragentsme } = require('useragents-me-api');
 
 async function main() {
   try {
-    const res = await useragentsme();
-    console.log(res); // [{"ua": "Mozilla/5.0...", "pct": 36.123...}, ...]
+    // Get most common mobile user agents
+    const res1 = await useragentsme();
+    console.log(res1); // [{"ua": "Mozilla/5.0...", "pct": 44.123...}, ...]
+    // Get most common desktop user agents
+    const res2 = await useragentsme('desktop');
+    console.log(res2); // [{"ua": "Mozilla/5.0...", "pct": 40.123...}, ...]
   } catch (error) {
     console.log(error);
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,8 @@ declare module 'useragents-me-api' {
   }
   /**
    * Get User Agents from useragents.me website as JSON
+   * @param {string} [uaType=mobile] - Specify type of agents: mobile, desktop
    * @return {Promise<UserAgent[]>}
    */
-  export function useragentsme(): Promise<UserAgent[]>;
+  export function useragentsme(uaType?: string): Promise<UserAgent[]>;
 }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const selectorIds = {
   mobile: '#most-common-mobile-useragents-json-csv',
   desktop: '#most-common-desktop-useragents-json-csv',
 };
+const validTypes = ['mobile', 'desktop'];
 
 /**
  * Scrape User Agents from useragents.me website textarea
@@ -15,8 +16,9 @@ const selectorIds = {
  */
 async function getJsonFromPage(uaType = 'mobile') {
   // Protect against UA types we do not have selectors for
-  if (!['mobile', 'desktop'].includes(uaType)) {
-    throw new Error(`Unsupported user-agent type specified: ${uaType}`);
+  if (!validTypes.includes(uaType)) {
+    throw new Error(`Invalid user-agent type: ${uaType}.
+      Valid types are: ${validTypes.join(', ')}`);
   }
 
   const selector = `${selectorIds[uaType]} > div:nth-child(1) > textarea`;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const website = 'https://www.useragents.me/';
 const selectorIds = {
   mobile: '#most-common-mobile-useragents-json-csv',
   desktop: '#most-common-desktop-useragents-json-csv',
-}
+};
 
 /**
  * Scrape User Agents from useragents.me website textarea
@@ -20,7 +20,6 @@ async function getJsonFromPage(uaType = 'mobile') {
   }
 
   const selector = `${selectorIds[uaType]} > div:nth-child(1) > textarea`;
-  console.error('selector', selector);
 
   try {
     const { data } = await axios.get(website);

--- a/index.js
+++ b/index.js
@@ -3,14 +3,25 @@ const cheerio = require('cheerio');
 
 // This is just a wrapper for https://www.useragents.me/ APIs
 const website = 'https://www.useragents.me/';
-const selectorId = '#most-common-mobile-useragents-json-csv';
-const selector = `${selectorId} > div:nth-child(1) > textarea`;
+const selectorIds = {
+  mobile: '#most-common-mobile-useragents-json-csv',
+  desktop: '#most-common-desktop-useragents-json-csv',
+}
 
 /**
  * Scrape User Agents from useragents.me website textarea
+ * @param {string} [uaType=mobile] - Specify type of agents: mobile, desktop
  * @return {Promise<Array>} Array of objects
  */
-async function getJsonFromPage() {
+async function getJsonFromPage(uaType = 'mobile') {
+  // Protect against UA types we do not have selectors for
+  if (!['mobile', 'desktop'].includes(uaType)) {
+    throw new Error(`Unsupported user-agent type specified: ${uaType}`);
+  }
+
+  const selector = `${selectorIds[uaType]} > div:nth-child(1) > textarea`;
+  console.error('selector', selector);
+
   try {
     const { data } = await axios.get(website);
     const $ = cheerio.load(data);
@@ -23,12 +34,13 @@ async function getJsonFromPage() {
 
 /**
  * Get User Agents from useragents.me website as JSON
+ * @param {string} [uaType=mobile] - Specify type of agents: mobile, desktop
  * @return {Promise<Array>} Array of objects such as:
  * [{ ua: string, pct: number }, ...]
  */
-async function useragentsme() {
+async function useragentsme(uaType = 'mobile') {
   try {
-    const userAgents = await getJsonFromPage();
+    const userAgents = await getJsonFromPage(uaType);
     return userAgents;
   } catch (error) {
     console.error(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "useragents-me-api",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "useragents-me-api",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",
@@ -16,7 +16,7 @@
         "eslint": "~8.57.1",
         "eslint-config-google": "^0.14.0",
         "husky": "^9.1.7",
-        "mocha": "^11.0.1",
+        "mocha": "^11.1.0",
         "nyc": "^17.1.0"
       }
     },
@@ -1214,14 +1214,18 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -2576,9 +2580,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.0.1.tgz",
-      "integrity": "sha512-+3GkODfsDG71KSCQhc4IekSW+ItCK/kiez1Z28ksWvYhKXV/syxMlerR/sC7whDp7IyreZ4YxceMLdTs5hQE8A==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
+      "integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2599,8 +2603,8 @@
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^6.5.1",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
       },
       "bin": {
@@ -3695,9 +3699,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
-      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -3805,6 +3809,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -3859,6 +3864,7 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -3870,30 +3876,32 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-unparser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "useragents-me-api",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Node.js wrapper for useragents.me",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,7 @@
     "eslint": "~8.57.1",
     "eslint-config-google": "^0.14.0",
     "husky": "^9.1.7",
-    "mocha": "^11.0.1",
+    "mocha": "^11.1.0",
     "nyc": "^17.1.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2,24 +2,36 @@ const assert = require('assert');
 const { useragentsme } = require('../index');
 
 describe('Tests for Useragents.me', () => {
-  it('should return an array of objects with user agents and pct', async () => {
+  it('should return an array of objects with mobile user agents', async () => {
     const res = await useragentsme();
     assert.ok(res.length > 0);
     assert.ok(Object.hasOwn(res[0], 'ua'));
     assert.ok(Object.hasOwn(res[0], 'pct'));
     assert.ok(typeof res[0].ua === 'string');
     assert.ok(typeof res[0].pct === 'number');
+    assert.ok(res[0].pct > 0);
+    assert.ok(res[0].ua.includes('Chrome'));
+    assert.ok(res[0].ua.includes('Mobile'));
   });
 
-  it(
-      'desktop should also return an array of objects with user agents and pct',
-      async () => {
-        const res = await useragentsme('desktop');
-        assert.ok(res.length > 0);
-        assert.ok(Object.hasOwn(res[0], 'ua'));
-        assert.ok(Object.hasOwn(res[0], 'pct'));
-        assert.ok(typeof res[0].ua === 'string');
-        assert.ok(typeof res[0].pct === 'number');
-      },
-  );
+  it('should return an array of objects with desktop user agents', async () => {
+    const res = await useragentsme('desktop');
+    assert.ok(res.length > 0);
+    assert.ok(Object.hasOwn(res[0], 'ua'));
+    assert.ok(Object.hasOwn(res[0], 'pct'));
+    assert.ok(typeof res[0].ua === 'string');
+    assert.ok(typeof res[0].pct === 'number');
+    assert.ok(res[0].pct > 0);
+    assert.ok(res[0].ua.includes('Chrome'));
+    assert.ok(!res[0].ua.includes('Mobile'));
+  });
+
+  it('should throw an error if user agent type is invalid', async () => {
+    try {
+      await useragentsme('invalid');
+      assert.fail('Invalid user-agent type');
+    } catch (error) {
+      assert.ok(error instanceof Error);
+    }
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -10,4 +10,16 @@ describe('Tests for Useragents.me', () => {
     assert.ok(typeof res[0].ua === 'string');
     assert.ok(typeof res[0].pct === 'number');
   });
+
+  it(
+      'desktop should also return an array of objects with user agents and pct',
+      async () => {
+        const res = await useragentsme('desktop');
+        assert.ok(res.length > 0);
+        assert.ok(Object.hasOwn(res[0], 'ua'));
+        assert.ok(Object.hasOwn(res[0], 'pct'));
+        assert.ok(typeof res[0].ua === 'string');
+        assert.ok(typeof res[0].pct === 'number');
+      },
+  );
 });


### PR DESCRIPTION
Adds the ability to specify whether you want to pull the list of mobile or desktop user agents by passing either `mobile` or `desktop` to `useragentsme()`.  Keeps default behavior of returning mobile if argument is passed.

### Tests Passing:
Added a new (identical) test for desktop

![image](https://github.com/user-attachments/assets/41a05f3d-3f9b-4c80-ab12-73b450760fe0)
